### PR TITLE
craite chengCameraScript

### DIFF
--- a/VGA_Game_project_team4/Assets/Sclipt/chengCamera.cs
+++ b/VGA_Game_project_team4/Assets/Sclipt/chengCamera.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class chengCamera : MonoBehaviour
+{
+    [SerializeField] Camera mc;
+    [SerializeField] Camera sc;
+    [SerializeField] float m_sabiStart = 1;
+    [SerializeField] float m_sabiEnd = 1;
+    // Start is called before the first frame update
+    void Start()
+    {
+        mc.enabled = true;
+        sc.enabled = false;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (m_sabiStart > 0)
+        {
+            m_sabiStart -= Time.deltaTime;
+        }
+        if (m_sabiStart < 0)
+        {
+            mc.enabled = false;
+            sc.enabled = true;
+            m_sabiEnd -= Time.deltaTime;
+        }
+        if (m_sabiEnd < 0)
+        {
+            mc.enabled = true;
+            sc.enabled = false;
+            m_sabiStart = 0;
+        }
+        
+    }
+}

--- a/VGA_Game_project_team4/Assets/Sclipt/chengCamera.cs.meta
+++ b/VGA_Game_project_team4/Assets/Sclipt/chengCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed84d8629d9e4bd40aff626f0911f034
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
カメラを切り替えるスクリプトを作りました。
sabistartとsabiendで設定した時間でｍｃ→sc→ｍｃの順番で切り替わります。
インスペクターはｍｃが最初から映すカメラ、ｓｃが切り替えたときに映すカメラでどちらもカメラオブジェクトを入れるようになっています。

sabistartはシーンを実行してから切り替わる時間を単位秒で設定できます。
sabiendは切り替わってから元に戻るまでの時間を単位秒で設定できます。
sabistartとsabiendはどちらもfloat型です。